### PR TITLE
Fix: hash jump judging & detecting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,8 +24,8 @@ import "@fontsource/roboto";
 import "simplebar-react/dist/simplebar.min.css";
 
 // hash router change to browser router
-if (window.location.hash) {
-  window.location.href = window.location.hash;
+if (window.location.hash && window.location.pathname === "/") {
+  window.location.href = new URL(window.location.hash, window.location.href).href;
 }
 
 const container = document.getElementById("root");


### PR DESCRIPTION
- Hash jump needs to judge whether the current page is `/` 
- Hash jump cannot directly call the hash value.